### PR TITLE
gettersへの移管

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -26,6 +26,9 @@
         />
       </v-app-bar>
       <v-content>
+        <v-card>
+          <v-card-text>category: </v-card-text>
+        </v-card>
         <v-container>
           <v-row
             align="center"
@@ -47,14 +50,14 @@
               <v-dialog
                 persistent
                 width="60%"
-                v-model="this.newTodo"
+                v-model="newTodoDialog"
               >
                 <new-todo />
               </v-dialog>
               <v-dialog
                 persistent
                 width="60%"
-                v-model="this.todoDetail"
+                v-model="todoDetailDialog"
               >
                 <todo-detail />
               </v-dialog>
@@ -83,7 +86,7 @@
   import Signup from './components/Dialog/Signup';
   import newTodo from './components/Dialog/NewTodo';
   import TodoDetail from './components/Dialog/TodoDetail';
-  import { mapState } from 'vuex';
+  import { mapGetters } from 'vuex';
 
   export default {
     components: {
@@ -102,10 +105,7 @@
       color: "indigo darken-4",
     }),
     computed: {
-      ...mapState({
-        newTodo: 'newTodoDialog',
-        todoDetail: 'todoDetailDialog'
-      })
+      ...mapGetters(['newTodoDialog', 'todoDetailDialog'])
     },
     mounted() {
       this.overlay = true

--- a/src/store/index.js
+++ b/src/store/index.js
@@ -21,7 +21,8 @@ export default new Vuex.Store({
     todoDetailDialog: false,
   },
   getters: {
-    newTodoDialog: state => state.newTodoDialog
+    newTodoDialog: state => state.newTodoDialog,
+    todoDetailDialog: state => state.todoDetailDialog
   },
   mutations: {
     toggleNewTodoDialog(state, bool) {


### PR DESCRIPTION
## what
- vuexのstateをvueファイルで使用する時にmapStateを使用していたものをmapGettersに変更

## why
- 情報の取得を全てgettersにすることにより、意図しないstateの変更が行われることを防止する。
- mutation以外での状態の変更を防ぐため。